### PR TITLE
Fix showing tree model

### DIFF
--- a/src/pdfobjectmodel.cpp
+++ b/src/pdfobjectmodel.cpp
@@ -493,7 +493,7 @@ void PdfObjectModelNode::SetData(const PdfVariant& variant)
 
 
 PdfObjectModel::PdfObjectModel(PdfMemDocument* doc, QObject* parent, bool catalogRooted)
-    : QAbstractTableModel(parent), m_bDocChanged(false), m_pTree(0)
+    : QAbstractItemModel(parent), m_bDocChanged(false), m_pTree(0)
 {
     if (catalogRooted)
         setupModelData_CatalogRooted(doc);

--- a/src/pdfobjectmodel.h
+++ b/src/pdfobjectmodel.h
@@ -3,7 +3,7 @@
 
 #include <utility>
 
-#include <QAbstractTableModel>
+#include <QAbstractItemModel>
 #include <QMap>
 
 #include <podofo/podofo.h>
@@ -35,7 +35,7 @@ namespace PoDoFo {
  *
  * All are Qt::DisplayRole roles with string values.
  */
-class PdfObjectModel : public QAbstractTableModel
+class PdfObjectModel : public QAbstractItemModel
 {
     Q_OBJECT
 


### PR DESCRIPTION
I compiled PoDoFoBrowser with Qt 5.13.2, starts it and open a .pdf file. And found that can't find expand catalog. No any tree. So I fix it. Anyway in Qt docs: *Since the model provides a more specialized interface than QAbstractItemModel, it is not suitable for use with tree views*.